### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 cache: bundler
 
 install:
+  # Install the right version of Bundler
+  # from https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html
+  - gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
   - make install
 
 script:

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
+ruby "2.6.3"
+
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,5 +80,8 @@ DEPENDENCIES
   tzinfo-data
   wdm (~> 0.1.1)
 
+RUBY VERSION
+   ruby 2.6.3p62
+
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
The first attempt to build the project on CI failed: https://travis-ci.org/github/DeadRooster/deadrooster.org/builds/670927410.

This PR aims to fix the error by: 
* installing the proper version of bundler during the CI install stage;
* using the same version of Ruby in the developer environment and CI.