### PR TITLE
Add Ruby version in Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+rvm:
+  - 2.6.3
 cache: bundler
 
 install:


### PR DESCRIPTION
This [PR](https://github.com/DeadRooster/deadrooster.org/pull/2) [failed](https://travis-ci.org/github/DeadRooster/deadrooster.org/builds/670937107) with the following error:

```
Your Ruby version is 2.5.3, but your Gemfile specified 2.6.3
```

So, on top of having the Ruby version in `Gemfile`, from [this Travis doc](https://docs.travis-ci.com/user/languages/ruby/#specifying-ruby-versions-and-implementations), we also need it in `.travis.yml`.