### PR TITLE
Add plugin to support the youtube tag

### DIFF
--- a/_plugins/youtube_tag.rb
+++ b/_plugins/youtube_tag.rb
@@ -1,0 +1,18 @@
+module Jekyll
+  class YouTubeTag < Liquid::Tag
+    def initialize(tag_name, text, tokens)
+      super
+      @youtube_id = text.strip
+    end
+
+    def render(context)
+      content = super
+      <<~EOD
+        <iframe width="560" height="315" src="https://www.youtube.com/embed/#{@youtube_id}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
+        </iframe>
+      EOD
+    end
+  end
+end
+
+Liquid::Template.register_tag('youtube', Jekyll::YouTubeTag)


### PR DESCRIPTION
This PR adds a plugin, as documented [here](https://jekyllrb.com/docs/plugins/installation/), with a very basic implementation for a `youtube` tag.  

So that the following syntax: 

```
{% youtube foo %}
```

can be used to embed the YouTube video with the `foo` id.

This PR fixes #9.