### PR TITLE
Add sitemap to the site

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
       git: 'https://github.com/envygeeks/jekyll-assets',
       branch: 'master'
   gem 'jekyll-feed', '~> 0.12'
+  gem 'jekyll-sitemap'
 end
 
 # Windows and JRuby does not include zoneinfo files,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,8 @@ GEM
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.6.1)
       jekyll (>= 3.3, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.1.0)
@@ -152,6 +154,7 @@ DEPENDENCIES
   jekyll (~> 4.0.0)
   jekyll-assets!
   jekyll-feed (~> 0.12)
+  jekyll-sitemap
   kids!
   rubocop
   tzinfo (~> 1.2)

--- a/_config.yml
+++ b/_config.yml
@@ -34,6 +34,7 @@ github_username: DeadRooster
 theme: kids
 plugins:
   - jekyll-feed
+  - jekyll-sitemap
 
 kids:
   # A boolean indicating if the site contains an Apple touch icon file


### PR DESCRIPTION
To improve the performance of Google Search Console, a sitemap was recommended.
Here it is.