### PR TITLE
Add dailymotion tag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/dirtyhenry/buckygem.git
-  revision: 7b3eb86fcd7c440027603489cee2b0fb3a16bbc4
+  revision: c4b2b76a4352aa032c8d3d0af1550f1fd6da813f
   branch: master
   specs:
     buckygem (0.6.0)
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/dirtyhenry/kids.git
-  revision: 3ccf2f78e34f236d515b5b97c944a9b0fb11ff0c
+  revision: d9112de647b3fec46b04acea99ccca70caccfcb1
   branch: master
   specs:
     kids (0.2.0)
@@ -118,7 +118,7 @@ GEM
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     parallel (1.19.2)
-    parser (2.7.1.4)
+    parser (2.7.1.5)
       ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
@@ -128,20 +128,20 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (1.8.0)
+    regexp_parser (1.8.1)
     rexml (3.2.4)
     rouge (3.23.0)
-    rubocop (0.91.1)
+    rubocop (0.92.0)
       parallel (~> 1.10)
-      parser (>= 2.7.1.1)
+      parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.7)
       rexml
-      rubocop-ast (>= 0.4.0, < 1.0)
+      rubocop-ast (>= 0.5.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.4.2)
-      parser (>= 2.7.1.4)
+    rubocop-ast (0.7.1)
+      parser (>= 2.7.1.5)
     ruby-enum (0.8.0)
       i18n
     ruby-progressbar (1.10.1)

--- a/_plugins/spotify_song_tag.rb
+++ b/_plugins/spotify_song_tag.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# The module to extend from a Jekyll project according to Jekyll's docs.
+module Jekyll
+  # A tag handling {% spotify_track track_id %}
+  # Example: {% spotify_track 6yt7RQR9MBtuCd3gjTuOuw %}
+  class SpotifyTrackTag < Liquid::Tag
+    def initialize(tag_name, text, tokens)
+      super
+      @track_id = text
+    end
+
+    def render(_context)
+      <<~RENDERED_HTML
+        <div>
+          <iframe src="https://open.spotify.com/embed/track/#{@track_id}" width="300" height="380" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+        </div>
+      RENDERED_HTML
+    end
+  end
+
+  Liquid::Template.register_tag('spotify_track', Jekyll::SpotifyTrackTag)
+end


### PR DESCRIPTION
This PR updates Buckygem & Kid to support additional tags, and add a Spotify individual track liquid tag.