### PR TITLE
Add support for tags and categories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'jekyll', '~> 4.0.0'
 # This is a lightweight Jekyll theme we want to use.
 gem 'kids',
     git: 'https://github.com/dirtyhenry/kids.git',
-    branch: 'master'
+    branch: 'tags-and-categories'
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,8 +10,8 @@ GIT
 
 GIT
   remote: https://github.com/dirtyhenry/kids.git
-  revision: 7a140d4fc4a327e33cdf933659f0d4123cb99fa3
-  branch: master
+  revision: 6f73d1cc42ae009886ff5e1c05efa6d7ab9b6ee2
+  branch: tags-and-categories
   specs:
     kids (0.2.0)
       buckygem (~> 0.5)
@@ -108,16 +108,16 @@ GEM
     liquid-tag-parser (2.0.2)
       extras (~> 0.3)
       liquid (>= 3.0, < 5.0)
-    listen (3.2.1)
+    listen (3.3.3)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_magick (4.10.1)
+    mini_magick (4.11.0)
     mini_portile2 (2.4.0)
     minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    parallel (1.19.2)
+    parallel (1.20.1)
     parser (2.7.2.0)
       ast (~> 2.4.1)
     pathutil (0.16.2)
@@ -128,19 +128,19 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    regexp_parser (1.8.1)
+    regexp_parser (2.0.0)
     rexml (3.2.4)
-    rouge (3.24.0)
-    rubocop (0.93.0)
+    rouge (3.25.0)
+    rubocop (1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.1.5)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8)
+      regexp_parser (>= 2.0)
       rexml
-      rubocop-ast (>= 0.6.0)
+      rubocop-ast (>= 1.2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.7.1)
+    rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-enum (0.8.0)
       i18n
@@ -154,13 +154,13 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2020.2)
+    tzinfo-data (1.2020.4)
       tzinfo (>= 1.0.0)
     unicode-display_width (1.7.0)
     wdm (0.1.1)
-    zeitwerk (2.4.1)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   ruby

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -8,9 +8,7 @@ layout: default
   {%- endif -%}
 
 {%- assign posts_by_month = site.categories[page.category] | group_by_exp: "item", "item.date | truncate: 7, ''" -%}
-
   {%- if posts_by_month.size > 0 -%}
-    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
     <ul class="post-list">
       {%- for month in posts_by_month -%}
       <li>
@@ -27,12 +25,5 @@ layout: default
       </li>
       {%- endfor -%}
     </ul>
-
-    <p class="feed-subscribe">
-      <a href="{{ 'feed.xml' | relative_url }}">
-        <span>Subscribe to our feed</span>
-      </a>
-    </p>
   {%- endif -%}
-
 </div>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -10,7 +10,6 @@ layout: default
 {%- assign posts_by_month = site.tags[page.tag] | group_by_exp: "item", "item.date | truncate: 7, ''" -%}
 
   {%- if posts_by_month.size > 0 -%}
-    <h2 class="post-list-heading">{{ page.list_title | default: "Posts" }}</h2>
     <ul class="post-list">
       {%- for month in posts_by_month -%}
       <li>
@@ -27,12 +26,6 @@ layout: default
       </li>
       {%- endfor -%}
     </ul>
-
-    <p class="feed-subscribe">
-      <a href="{{ 'feed.xml' | relative_url }}">
-        <span>Subscribe to our feed</span>
-      </a>
-    </p>
   {%- endif -%}
 
 </div>

--- a/_plugins/category_page_generator.rb
+++ b/_plugins/category_page_generator.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'i18n'
+require 'liquid'
 
 def slugify(string)
   I18n.available_locales = %i[en fr]
@@ -29,6 +30,7 @@ module Jekyll
 
   # A Page subclass used in the `CategoryPageGenerator`
   class CategoryPage < Page
+    # rubocop:disable Lint/MissingSuper
     def initialize(site, base, dir, category)
       @site = site
       @base = base
@@ -43,4 +45,14 @@ module Jekyll
       data['title'] = "#{category_title_prefix}#{category}"
     end
   end
+  # rubocop:enable Lint/MissingSuper
+
+  # A Liquid filter to generate the path of a category resource.
+  module CategoryLinkFilter
+    def category_link(input)
+      "/categories/#{slugify(input)}"
+    end
+  end
 end
+
+Liquid::Template.register_filter(Jekyll::CategoryLinkFilter)

--- a/_plugins/tag_page_generator.rb
+++ b/_plugins/tag_page_generator.rb
@@ -30,6 +30,7 @@ module Jekyll
 
   # A Page subclass used in the `TagPageGenerator`
   class TagPage < Page
+    # rubocop:disable Lint/MissingSuper
     def initialize(site, base, dir, tag)
       @site = site
       @base = base
@@ -43,5 +44,15 @@ module Jekyll
       tag_title_prefix = site.config['tag_title_prefix'] || 'Tag: '
       data['title'] = "#{tag_title_prefix}#{tag}"
     end
+    # rubocop:enable Lint/MissingSuper
+  end
+
+  # A Liquid filter to generate the path of a tag resource.
+  module TagLinkFilter
+    def tag_link(input)
+      "/tags/#{slugify(input)}"
+    end
   end
 end
+
+Liquid::Template.register_filter(Jekyll::TagLinkFilter)


### PR DESCRIPTION
This PR leverages the content of https://github.com/dirtyhenry/kids/pull/48 to include tags and categories links within Dead Rooster.