### PR TITLE
Announce repository archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # 🐔 Dead Rooster: the engine
 
+> [!IMPORTANT]
+> 🇫🇷 Ce dépôt est archivé et deviendra bientôt privé — sa maintenance continue
+> dans un monorepo privé. **[deadrooster.org][3] reste en ligne** : continuez à
+> nous lire sur le site et via le [flux RSS][7].
+>
+> 🇬🇧 This repository is archived and will soon become private — maintenance
+> continues in a private monorepo. **[deadrooster.org][3] is still online**:
+> keep reading us on the site and via the [RSS feed][7].
+
 This repository contains the code running [deadrooster.org][3].
 
 The articles of the site are on [dirtyhenry/dead-rooster-articles][4].
@@ -22,7 +31,6 @@ succès :
 ## Follow
 
 - Follow us: [RSS Feed][7]
-- Talk to us: [GitHub Discussions][8]
 
 ## Deployment
 
@@ -41,4 +49,3 @@ An older version of the site was using [Alternate Gothic 2][2].
   https://www.deadrooster.org/category/encyclopedie-approximative-du-rock-and-roll/
 [6]: https://www.deadrooster.org/category/le-monde-va-mal/
 [7]: https://www.deadrooster.org/feed.xml
-[8]: https://github.com/dirtyhenry/dead-rooster-articles/discussions


### PR DESCRIPTION
Adds a bilingual (FR/EN) notice at the top of the README: this repository is archived and will soon become private — maintenance continues in a private monorepo, and **deadrooster.org stays online**.

Also removes the GitHub Discussions link, since Discussions will no longer be publicly accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)